### PR TITLE
fix: predict correct probability score ML and handle main category training errors

### DIFF
--- a/app/signals/apps/classification/admin/admins.py
+++ b/app/signals/apps/classification/admin/admins.py
@@ -68,7 +68,7 @@ class TrainingSetAdmin(admin.ModelAdmin):
                     )
                 return
 
-            # Check if there are no subcategories present in the training set that are not present in the database
+            # Check if there are no sub categories present in the training set that are not present in the database
             sub_col_index = headers.index("Sub")
             subcategory_values = {row[sub_col_index] for row in data_rows if row[sub_col_index]}
             existing_subcategories = set(Category.objects.filter(name__in=subcategory_values).values_list('name', flat=True))
@@ -77,7 +77,22 @@ class TrainingSetAdmin(admin.ModelAdmin):
             if missing_subcategories:
                 self.message_user(
                     request,
-                    f"The training set {training_set.name} contains unknown subcategories: {', '.join(missing_subcategories)}. Add these to Signalen before continuing.",
+                    f"The training set {training_set.name} contains unknown sub categories: {', '.join(missing_subcategories)}. Add these to Signalen before continuing.",
+                    messages.ERROR
+                )
+                return
+
+            # Check if there are no main categories present in the training set that are not present in the database
+            main_col_index = headers.index("Main")
+            maincategory_values = {row[main_col_index] for row in data_rows if row[main_col_index]}
+            existing_maincategories = set(
+                Category.objects.filter(name__in=maincategory_values).values_list('name', flat=True))
+            missing_maincategories = maincategory_values - existing_maincategories
+
+            if missing_maincategories:
+                self.message_user(
+                    request,
+                    f"The training set {training_set.name} contains unknown main categories: {', '.join(missing_maincategories)}. Add these to Signalen before continuing.",
                     messages.ERROR
                 )
                 return

--- a/app/signals/apps/classification/views.py
+++ b/app/signals/apps/classification/views.py
@@ -74,24 +74,26 @@ class MlPredictCategoryView(APIView):
             text = request.data['text']
 
             # Get prediction and probability for the main model
-            main_prediction = main_model.predict([text])
-            main_probability = main_model.predict_proba([text])
+            main_prediction = main_model.predict([text])[0]
+            main_proba = main_model.predict_proba([text])[0]
+            main_index = list(main_model.classes_).index(main_prediction)
+            main_prob = main_proba[main_index]
 
             # Get prediction and probability for the sub model
-            sub_prediction = sub_model.predict([text])
-            sub_probability = sub_model.predict_proba([text])
-
-            main_slug = main_prediction[0]
-            sub_slug = sub_prediction[0].split('|')[1]
+            sub_prediction = sub_model.predict([text])[0]
+            sub_proba = sub_model.predict_proba([text])[0]
+            sub_category = sub_prediction.split('|')[1]
+            sub_index = list(sub_model.classes_).index(sub_prediction)
+            sub_prob = sub_proba[sub_index]
 
             data = {
                 'hoofdrubriek': [
-                    [settings.BACKEND_URL + f'/signals/v1/public/terms/categories/{main_slug}'],
-                    [main_probability[0][0]]
+                    [settings.BACKEND_URL + f'/signals/v1/public/terms/categories/{main_prediction}'],
+                    [main_prob],
                 ],
                 'subrubriek': [
-                    [settings.BACKEND_URL + f'/signals/v1/public/terms/categories/{main_slug}/sub_categories/{sub_slug}'],
-                    [sub_probability[0][0]]
+                    [settings.BACKEND_URL + f'/signals/v1/public/terms/categories/{main_prediction}/sub_categories/{sub_category}'],
+                    [sub_prob]
                 ]
             }
         except Exception as e:


### PR DESCRIPTION
**Description**
- Show correct probability score in ML prediction response
- Show error during training if there are main categories present in the training set that are not present in Signalen

**Explanation**
When calling the predict endpoint, both the main and subcategory probability scores were predicted using the output of the .predict_proba() function. However, the implementation always returned the first result from the predict_proba() output, regardless of which class actually had the highest probability. This caused incorrect predictions when the highest-probability class was not at index 0.



