### PR TITLE
feat: Signalen app notifications

### DIFF
--- a/app/signals/apps/notifications/apps.py
+++ b/app/signals/apps/notifications/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class NotificationsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'signals.apps.notifications'
+    verbose_name = 'Notifications'
+
+    def ready(self):
+        from . import signal_receivers  # noqa

--- a/app/signals/apps/notifications/signal_receivers.py
+++ b/app/signals/apps/notifications/signal_receivers.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2025 Delta10 B.V.
+import logging
+
+from django.dispatch import receiver
+
+from signals.apps.signals.managers import update_status
+
+from . import tasks
+from ..signals.models import Signal, Status
+from ..signals.workflow import STATUS_CHOICES
+from ... import settings
+
+logger = logging.getLogger(__name__)
+
+@receiver(update_status, dispatch_uid='update_status_send_notification')
+def send_notification_for_updated_signal_status(sender, signal_obj: Signal, status: Status, *args, **kwargs):
+    if not settings.FEATURE_FLAGS['SEND_NOTIFICATIONS_TO_SIGNALEN_APP']:
+        return
+
+    municipality_code = settings.MUNICIPALITY_CODE
+
+    if not municipality_code:
+        logger.warning("There is no MUNICIPALITY_CODE environment variable in the environment configured")
+        return
+
+    STATUS_DICT = dict(STATUS_CHOICES)
+    status_label = STATUS_DICT.get(status.state, status.state)
+    message = f"De status van uw melding SIG-{signal_obj.pk} is aangepast naar: {status_label.lower()}."
+
+    tasks.send_notification.delay(
+        municipality_code=municipality_code,
+        message=message,
+        signal_id=signal_obj.pk,
+        notification_type="Status_Update"
+    )

--- a/app/signals/apps/notifications/tasks.py
+++ b/app/signals/apps/notifications/tasks.py
@@ -1,0 +1,36 @@
+import logging
+
+from signals import settings
+from signals.celery import app
+import requests
+
+logger = logging.getLogger(__name__)
+
+@app.task
+def send_notification(municipality_code: str, message: str, signal_id: int, notification_type: str) -> None:
+    if not settings.SIGNALEN_APP_BACKEND_URL:
+        logger.warning("There is no SIGNALEN_APP_BACKEND_URL environment variable in the environment configured")
+        return
+
+    if not settings.SIGNALEN_APP_BACKEND_SECRET:
+        logger.warning("There is no SIGNALEN_APP_BACKEND_SECRET environment variable in the environment configured")
+        return
+
+    try:
+        response = requests.post(
+            f"{settings.SIGNALEN_APP_BACKEND_URL}/signalen/notifications",
+            json={
+                "payload": message,
+                "signal_id": signal_id,
+                "notification_type": notification_type,
+                "municipality_code": municipality_code,
+            },
+            headers={
+                'Content-Type': 'application/json',
+                'Authorization': f'Bearer {settings.SIGNALEN_APP_BACKEND_SECRET}'
+            }
+        )
+
+        response.raise_for_status()
+    except Exception as e:
+        logging.info(f"Sending notification for {notification_type} for SIG-{signal_id} went wrong: {e}")

--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -85,6 +85,7 @@ SIGNAL_APPS: list[str] = [
     'signals.apps.classification',
     'signals.apps.relations',
     'signals.apps.automation',
+    'signals.apps.notifications',
 ]
 
 INSTALLED_APPS: list[str] = [
@@ -513,6 +514,12 @@ SIGNALS_API_GEO_PAGINATE_BY: int = int(os.getenv(
 
 TEST_LOGIN: str = os.getenv('TEST_LOGIN', 'signals.admin@example.com')
 
+# Signalen App backend related environment variables
+MUNICIPALITY_CODE: str = os.getenv("MUNICIPALITY_CODE", None)
+SIGNALEN_APP_BACKEND_URL: str = os.getenv("SIGNALEN_APP_BACKEND_URL", None)
+SIGNALEN_APP_BACKEND_SECRET: str = os.getenv("SIGNALEN_APP_BACKEND_SECRET", None)
+
+
 # Feature Flags
 FEATURE_FLAGS: dict[str, bool] = {
     'API_DETERMINE_STADSDEEL_ENABLED': os.getenv('API_DETERMINE_STADSDEEL_ENABLED', True) in TRUE_VALUES,
@@ -540,6 +547,9 @@ FEATURE_FLAGS: dict[str, bool] = {
 
     # Run routing expressions again when updating signal subcategory or location
     'DSL_RUN_ROUTING_EXPRESSIONS_ON_UPDATES': os.getenv('DSL_RUN_ROUTING_EXPRESSIONS_ON_UPDATES', False) in TRUE_VALUES,
+
+    # Send notifications to Signalen App if this is enabled (Disabled by default)
+    'SEND_NOTIFICATIONS_TO_SIGNALEN_APP': os.getenv('SEND_NOTIFICATIONS_TO_SIGNALEN_APP', False) in TRUE_VALUES,
 }
 
 # Per default log to console


### PR DESCRIPTION
### Feature: Send Notifications via Signalen App Backend

This change introduces the ability to send notifications to the Signalen app backend when the status of a Signal changes.

#### New Configuration Options

The following configuration options have been added:

- `SIGNALEN_APP_BACKEND_URL`: The base URL of the Signalen app backend.
- `SIGNALEN_APP_BACKEND_SECRET`: The secret used to authorize requests to `/signalen/notifications`. This must match the secret configured in the Signalen app backend.
- `MUNICIPALITY_CODE`: The code for the municipality (e.g., `nl_1948`).
- `SEND_NOTIFICATIONS_TO_SIGNALEN_APP`: A new feature flag. Defaults to `False`. When set to `True`, it enables sending notifications to the Signalen app backend on status changes of a Signal.
